### PR TITLE
Make result cacheable

### DIFF
--- a/src/cson-loader.coffee
+++ b/src/cson-loader.coffee
@@ -1,4 +1,5 @@
 cson = require 'cson-safe'
 
 module.exports = (contents) ->
+  @cacheable?()
   "module.exports = " + cson.stringify cson.parse contents


### PR DESCRIPTION
Use the webpack loader API to mark the result deterministic and thus cacheable
